### PR TITLE
added_mult.yaml_file

### DIFF
--- a/.github/workflows/integration-libssh.yml
+++ b/.github/workflows/integration-libssh.yml
@@ -1,0 +1,44 @@
+---
+name: Integration tests 💻
+on:
+  pull_request_target:
+    branches: [main]
+    types:
+      - labeled
+      - opened
+      - reopened
+      - synchronize
+    paths:
+      - "plugins/**"
+      - "tests/integration/**"
+  workflow_dispatch:
+jobs:
+  lab-create:
+    uses: ansible/ansible-content-actions/.github/workflows/cml_lab_create.yaml@main
+    with:
+      topology_path: tests/integration/labs/multi.yaml
+      # lab_title_override: "Optional custom lab title"
+    secrets:
+      virl_host: ${{ secrets.VIRL_HOST }}
+      virl_username: ${{ secrets.VIRL_USERNAME }}
+      virl_password: ${{ secrets.VIRL_PASSWORD }}
+
+  integration-tests:
+    needs: lab-create
+    strategy:
+      fail-fast: true
+      matrix:
+        ansible_version: ["stable-2.16", "stable-2.18", "stable-2.19", "milestone", "devel"]
+    uses: ansible/ansible-content-actions/.github/workflows/cml_network_integration.yaml@main
+    with:
+      ansible_version: ${{ matrix.ansible_version }}
+      lab_nodes: ${{ needs.lab-create.outputs.lab_nodes_json }}
+
+  lab-destroy:
+    if: ${{ always() }}
+    needs: integration-tests
+    uses: ansible/ansible-content-actions/.github/workflows/cml_lab_destroy.yaml@main
+    secrets:
+      virl_host: ${{ secrets.VIRL_HOST }}
+      virl_username: ${{ secrets.VIRL_USERNAME }}
+      virl_password: ${{ secrets.VIRL_PASSWORD }}

--- a/tests/integration/labs/inventory.j2
+++ b/tests/integration/labs/inventory.j2
@@ -1,0 +1,14 @@
+[iosxr]
+BATMON
+
+[iosxr:vars]
+ansible_host={{ ansible_host }}
+ansible_network_os={{ ansible_network_os | default('cisco.iosxr.iosxr') }}
+ansible_user={{ ansible_user | default('ansible') }}
+ansible_ssh_pass={{ ansible_ssh_pass | default('lab') }}
+ansible_connection="ansible.netcommon.network_cli"
+ansible_network_cli_ssh_type={{ ansible_network_cli_ssh_type | default('libssh') }}
+ansible_ssh_port={{ ansible_ssh_port }}
+ansible_become={{ ansible_become | default(false) }}
+ansible_become_password={{ ansible_become_password | default('cisco') }}```
+

--- a/tests/integration/labs/multi.yaml
+++ b/tests/integration/labs/multi.yaml
@@ -1,0 +1,391 @@
+---
+annotations:
+  - border_color: "#0C0606"
+    border_radius: 0
+    border_style: ""
+    color: "#1A8FE43C"
+    thickness: 1
+    type: rectangle
+    x1: -520.0
+    y1: -200.0
+    x2: 880.0
+    y2: 400.0
+    z_index: 0
+  - border_color: "#808080FF"
+    border_radius: 0
+    border_style: ""
+    color: "#FFFFFFFF"
+    thickness: 1
+    type: rectangle
+    x1: -480.0
+    y1: 40.0
+    x2: 800.0
+    y2: 160.0
+    z_index: 1
+  - border_color: "#808080FF"
+    border_radius: 0
+    border_style: ""
+    color: "#FFFFFFFF"
+    thickness: 1
+    type: rectangle
+    x1: -400.0
+    y1: -80.0
+    x2: 640.0
+    y2: 120.0
+    z_index: 2
+  - border_color: "#808080FF"
+    border_radius: 0
+    border_style: ""
+    color: "#FABEBE7C"
+    thickness: 1
+    type: rectangle
+    x1: -200.0
+    y1: -200.0
+    x2: 240.0
+    y2: 120.0
+    z_index: 3
+  - border_color: "#00000000"
+    border_style: ""
+    color: "#808080FF"
+    rotation: 0
+    text_bold: false
+    text_content: CISCO.IOSXR Automated lab
+    text_font: monospace
+    text_italic: false
+    text_size: 12
+    text_unit: pt
+    thickness: 1
+    type: text
+    x1: -480.0
+    y1: -160.0
+    z_index: 4
+  - border_color: "#00000000"
+    border_style: ""
+    color: "#808080FF"
+    rotation: 0
+    text_bold: false
+    text_content: for upstream tests
+    text_font: monospace
+    text_italic: false
+    text_size: 12
+    text_unit: pt
+    thickness: 1
+    type: text
+    x1: -480.0
+    y1: -120.0
+    z_index: 5
+nodes:
+  - boot_disk_size: null
+    configuration: &conf |2-
+      !! IOS XR Configuration
+      hostname R1
+      username ansible
+       group root-lr
+       group cisco-support
+       password 0 lab
+      !
+      interface MgmtEth0/RP0/CPU0/0
+       ipv4 address dhcp
+       no shutdown
+      !
+      interface GigabitEthernet0/0/0/0
+       shutdown
+      !
+      router static
+       address-family ipv4 unicast
+        0.0.0.0/0 192.168.255.1
+       !
+      !
+      ssh server v2
+      netconf-yang agent
+       ssh
+      !
+    cpu_limit: null
+    cpus: null
+    data_volume: null
+    hide_links: false
+    id: n0
+    image_definition: null
+    label: milestone
+    node_definition: iosxrv9000
+    parameters: {}
+    ram: null
+    tags: []
+    x: -400
+    y: 120
+    interfaces:
+      - id: i0
+        label: Loopback0
+        type: loopback
+      - id: i1
+        label: MgmtEth0/RP0/CPU0/0
+        slot: 0
+        type: physical
+      - id: i2
+        label: donotuse1
+        slot: 1
+        type: physical
+      - id: i3
+        label: donotuse2
+        slot: 2
+        type: physical
+      - id: i4
+        label: GigabitEthernet0/0/0/0
+        slot: 3
+        type: physical
+  - boot_disk_size: null
+    configuration: *conf
+    cpu_limit: null
+    cpus: null
+    data_volume: null
+    hide_links: false
+    id: n1
+    image_definition: null
+    label: devel
+    node_definition: iosxrv9000
+    parameters: {}
+    ram: null
+    tags: []
+    x: -240
+    y: 120
+    interfaces:
+      - id: i0
+        label: Loopback0
+        type: loopback
+      - id: i1
+        label: MgmtEth0/RP0/CPU0/0
+        slot: 0
+        type: physical
+      - id: i2
+        label: donotuse1
+        slot: 1
+        type: physical
+      - id: i3
+        label: donotuse2
+        slot: 2
+        type: physical
+      - id: i4
+        label: GigabitEthernet0/0/0/0
+        slot: 3
+        type: physical
+  - boot_disk_size: null
+    configuration: *conf
+    cpu_limit: null
+    cpus: null
+    data_volume: null
+    hide_links: false
+    id: n2
+    image_definition: null
+    label: stable-2.18
+    node_definition: iosxrv9000
+    parameters: {}
+    ram: null
+    tags: []
+    x: -80
+    y: 120
+    interfaces:
+      - id: i0
+        label: Loopback0
+        type: loopback
+      - id: i1
+        label: MgmtEth0/RP0/CPU0/0
+        slot: 0
+        type: physical
+      - id: i2
+        label: donotuse1
+        slot: 1
+        type: physical
+      - id: i3
+        label: donotuse2
+        slot: 2
+        type: physical
+      - id: i4
+        label: GigabitEthernet0/0/0/0
+        slot: 3
+        type: physical
+  - boot_disk_size: null
+    configuration: *conf
+    cpu_limit: null
+    cpus: null
+    data_volume: null
+    hide_links: false
+    id: n3
+    image_definition: null
+    label: stable-2.19
+    node_definition: iosxrv9000
+    parameters: {}
+    ram: null
+    tags: []
+    x: 80
+    y: 120
+    interfaces:
+      - id: i0
+        label: Loopback0
+        type: loopback
+      - id: i1
+        label: MgmtEth0/RP0/CPU0/0
+        slot: 0
+        type: physical
+      - id: i2
+        label: donotuse1
+        slot: 1
+        type: physical
+      - id: i3
+        label: donotuse2
+        slot: 2
+        type: physical
+      - id: i4
+        label: GigabitEthernet0/0/0/0
+        slot: 3
+        type: physical
+  - boot_disk_size: null
+    configuration: *conf
+    cpu_limit: null
+    cpus: null
+    data_volume: null
+    hide_links: false
+    id: n4
+    image_definition: null
+    label: stable-2.16
+    node_definition: iosxrv9000
+    parameters: {}
+    ram: null
+    tags: []
+    x: 240
+    y: 120
+    interfaces:
+      - id: i0
+        label: Loopback0
+        type: loopback
+      - id: i1
+        label: MgmtEth0/RP0/CPU0/0
+        slot: 0
+        type: physical
+      - id: i2
+        label: donotuse1
+        slot: 1
+        type: physical
+      - id: i3
+        label: donotuse2
+        slot: 2
+        type: physical
+      - id: i4
+        label: GigabitEthernet0/0/0/0
+        slot: 3
+        type: physical
+  - boot_disk_size: null
+    configuration: []
+    cpu_limit: null
+    cpus: null
+    data_volume: null
+    hide_links: false
+    id: n5
+    image_definition: null
+    label: slave-switch
+    node_definition: unmanaged_switch
+    parameters: {}
+    ram: null
+    tags: []
+    x: -80
+    y: -40
+    interfaces:
+      - id: i0
+        label: port0
+        slot: 0
+        type: physical
+      - id: i1
+        label: port1
+        slot: 1
+        type: physical
+      - id: i2
+        label: port2
+        slot: 2
+        type: physical
+      - id: i3
+        label: port3
+        slot: 3
+        type: physical
+      - id: i4
+        label: port4
+        slot: 4
+        type: physical
+      - id: i5
+        label: port5
+        slot: 5
+        type: physical
+      - id: i6
+        label: port6
+        slot: 6
+        type: physical
+      - id: i7
+        label: port7
+        slot: 7
+        type: physical
+  - boot_disk_size: null
+    configuration: []
+    cpu_limit: null
+    cpus: null
+    data_volume: null
+    hide_links: false
+    id: n6
+    image_definition: null
+    label: ci-god
+    node_definition: external_connector
+    parameters: {}
+    ram: null
+    tags: []
+    x: -80
+    y: -160
+    interfaces:
+      - id: i0
+        label: port
+        slot: 0
+        type: physical
+links:
+  - id: l0
+    n1: n6
+    n2: n5
+    i1: i0
+    i2: i0
+    conditioning: {}
+    label: ci-god-port<->slave-switch-port0
+  - id: l1
+    n1: n5
+    n2: n0
+    i1: i1
+    i2: i1
+    conditioning: {}
+    label: slave-switch-port1<->milestone-mgmt0
+  - id: l2
+    n1: n5
+    n2: n1
+    i1: i2
+    i2: i1
+    conditioning: {}
+    label: slave-switch-port2<->devel-mgmt0
+  - id: l3
+    n1: n5
+    n2: n2
+    i1: i3
+    i2: i1
+    conditioning: {}
+    label: slave-switch-port3<->stable-2.18-mgmt0
+  - id: l4
+    n1: n5
+    n2: n3
+    i1: i4
+    i2: i1
+    conditioning: {}
+    label: slave-switch-port4<->stable-2.19-mgmt0
+  - id: l5
+    n1: n5
+    n2: n4
+    i1: i5
+    i2: i1
+    conditioning: {}
+    label: slave-switch-port5<->stable-2.16-mgmt0
+lab:
+  description: "Upstream test lab for cisco.iosxr"
+  notes: "Upstream test lab for cisco.iosxr"
+  title: cisco.iosxr.iosxr
+  version: 0.2.2


### PR DESCRIPTION
## Summary by Sourcery

Add a multi-node CML lab definition, inventory template, and GitHub Actions workflow for libssh-based integration tests across multiple Ansible versions.

CI:
- Introduce integration-libssh.yml workflow to provision and tear down CML labs and execute network integration tests with libssh across multiple Ansible versions

Tests:
- Add multi-node CML lab topology in tests/integration/labs/multi.yaml
- Add Jinja2 inventory template for Ansible integration tests in tests/integration/labs/inventory.j2